### PR TITLE
New CompadreData structure, new accessor methods, all functions use accessor methods

### DIFF
--- a/R/ClassUnionMethods.R
+++ b/R/ClassUnionMethods.R
@@ -5,25 +5,28 @@
 ################################################################################
 #' Accessor methods for CompadreM and CompadreData objects
 #'
-#' This page describes methods for both the CompadreM and CompadreData classes. 
-#' In many cases the same method can be used for both classes, but some methods
-#' are only valid for one class.
+#' Most methods for working with matrices are applicable to both CompadreM and 
+#' CompadreData objects. These are described on this page (along with a couple) 
+#' of methods applicable to only CompadreM or CompadreData objects).
 #' 
-#' @rdname CompadreUnionMethods
+#' @rdname CompadreMatrixMethods
 
 # Set class union for the two classes. Each class 'contains' the class union, 
 # so methods set for the union can be used by both classes.
 setClassUnion("CompadreMorData", c("CompadreM", "CompadreData"))
 
 # matA
-#' @rdname CompadreUnionMethods
+#' @rdname CompadreMatrixMethods
 #' @export
 setGeneric("matA", 
                function(object){
                    standardGeneric("matA")
                }
 )
-#' @rdname CompadreUnionMethods
+#' The 'matA' function extracts the matA (projection) matrix from a CompadreM 
+#' or CompadreData object. For CompadreM objects, this is a single matrix, 
+#' for CompadreData objects this is a list of matrices.
+#' @rdname CompadreMatrixMethods
 #' @export
 setMethod("matA", signature = "CompadreMorData", 
           function(object){
@@ -31,20 +34,24 @@ setMethod("matA", signature = "CompadreMorData",
               return(object@matA)
             }
             if(class(object) %in% "CompadreData"){
-              return( lapply(object@mat, function(M){ M@matA }) )
+              return( lapply(object@data$mat, function(M){ M@matA }) )
             }
           }
 )
 
+
 # matU
-#' @rdname CompadreUnionMethods
+#' The 'matU' function extracts the matU (survival) matrix from a CompadreM 
+#' or CompadreData object. For CompadreM objects, this is a single matrix, 
+#' for CompadreData objects this is a list of matrices.
+#' @rdname CompadreMatrixMethods
 #' @export
 setGeneric("matU", 
                function(object){
                    standardGeneric("matU")
                }
 )
-#' @rdname CompadreUnionMethods
+#' @rdname CompadreMatrixMethods
 #' @export
 setMethod("matU", signature = "CompadreMorData", 
           function(object){
@@ -52,20 +59,22 @@ setMethod("matU", signature = "CompadreMorData",
               return(object@matU)
             }
             if(class(object) %in% "CompadreData"){
-              return( lapply(object@mat, function(M){ M@matU }) )
+              return( lapply(object@data$mat, function(M){ M@matU }) )
             }
           }
 )
 
-# matF
-#' @rdname CompadreUnionMethods
+#' The 'matF' function extracts the matF (sexual reproduction) matrix from a CompadreM 
+#' or CompadreData object. For CompadreM objects, this is a single matrix, 
+#' for CompadreData objects this is a list of matrices.
+#' @rdname CompadreMatrixMethods
 #' @export
 setGeneric("matF", 
                function(object){
                    standardGeneric("matF")
                }
 )
-#' @rdname CompadreUnionMethods
+#' @rdname CompadreMatrixMethods
 #' @export
 setMethod("matF", signature = "CompadreMorData", 
           function(object){
@@ -73,20 +82,23 @@ setMethod("matF", signature = "CompadreMorData",
               return(object@matF)
             }
             if(class(object) %in% "CompadreData"){
-              return( lapply(object@mat, function(M){ M@matF }) )
+              return( lapply(object@data$mat, function(M){ M@matF }) )
             }
           }
 )
 
 # matC
-#' @rdname CompadreUnionMethods
+#' The 'matC' function extracts the matC (clonal reproduction) matrix from a CompadreM 
+#' or CompadreData object. For CompadreM objects, this is a single matrix, 
+#' for CompadreData objects this is a list of matrices.
+#' @rdname CompadreMatrixMethods
 #' @export
 setGeneric("matC", 
                function(object){
                    standardGeneric("matC")
                }
 )
-#' @rdname CompadreUnionMethods
+#' @rdname CompadreMatrixMethods
 #' @export
 setMethod("matC", signature = "CompadreMorData", 
           function(object){
@@ -94,7 +106,7 @@ setMethod("matC", signature = "CompadreMorData",
               return(object@matC)
             }
             if(class(object) %in% "CompadreData"){
-              return( lapply(object@mat, function(M){ M@matC }) )
+              return( lapply(object@data$mat, function(M){ M@matC }) )
             }
           }
 )
@@ -102,14 +114,18 @@ setMethod("matC", signature = "CompadreMorData",
 ## matrixClass slot
 
 # matrixClass
-#' @rdname CompadreUnionMethods
+#' The 'matrixClass' function extracts the matrixClass data frame from a CompadreM 
+#' or CompadreData object. For CompadreM objects, this is a single data frame, 
+#' for CompadreData objects this is a list of data frames. The matrixClass data
+#' includes information on the matrix, e.g. names of stages.
+#' @rdname CompadreMatrixMethods
 #' @export
 setGeneric("matrixClass", 
                function(object){
                    standardGeneric("matrixClass")
                }
 )
-#' @rdname CompadreUnionMethods
+#' @rdname CompadreMatrixMethods
 #' @export
 setMethod("matrixClass", signature = "CompadreMorData", 
           function(object){
@@ -117,18 +133,24 @@ setMethod("matrixClass", signature = "CompadreMorData",
               return(object@matrixClass)
             }
             if(class(object) %in% "CompadreData"){
-              return( lapply(object@mat, function(M){ M@matrixClass }) )
+              return( lapply(object@data$mat, function(M){ M@matrixClass }) )
             }
           }
 )
 
 # stageNames (MatrixClassAuthor)
+#' The 'matrixClassAuthor' and 'stageNames' functions extract the matrixClassAuthor column from 
+#' the matrixClass data frame from a CompadreM or CompadreData object. 
+#' For CompadreM objects, this is a single character vector, for CompadreData objects 
+#' this is a list of character vectors. The matrixClassAuthor data
+#' describes the names of the stages as determined by the author of the original 
+#' work the matrix was sourced from.
 setGeneric("stageNames", 
                function(object){
                    standardGeneric("stageNames")
                }
 )
-#' @rdname CompadreUnionMethods
+#' @rdname CompadreMatrixMethods
 #' @export
 setMethod("stageNames", signature = "CompadreMorData", 
           function(object){
@@ -136,8 +158,67 @@ setMethod("stageNames", signature = "CompadreMorData",
               return(object@matrixClass$MatrixClassAuthor)
             }
             if(class(object) %in% "CompadreData"){
-              return( sapply(object@mat, function(M){ M@matrixClass$matrixClassAuthor }) )
+              return( lapply(object@data$mat, function(M){ M@matrixClass$matrixClassAuthor }) )
+            }
+          }
+)
+setGeneric("MatrixClassAuthor", 
+               function(object){
+                   standardGeneric("MatrixClassAuthor")
+               }
+)
+#' @rdname CompadreMatrixMethods
+#' @export
+setMethod("MatrixClassAuthor", signature = "CompadreMorData", 
+          function(object){
+            if(class(object) %in% "CompadreM"){
+              return(object@matrixClass$MatrixClassAuthor)
+            }
+            if(class(object) %in% "CompadreData"){
+              return( lapply(object@data$mat, function(M){ M@matrixClass$matrixClassAuthor }) )
             }
           }
 )
 
+
+# stageStatus (matrixClassOrganized)
+#' The 'matrixClassAuthor' function extracts the matrixClassAuthor column from 
+#' the matrixClass data frame from a CompadreM or CompadreData object. 
+#' For CompadreM objects, this is a single character vector, for CompadreData objects 
+#' this is a list of character vectors. The matrixClassAuthor data
+#' describes the names of the stages as determined by the author of the original 
+#' work the matrix was sourced from.
+setGeneric("stageStatus", 
+               function(object){
+                   standardGeneric("stageStatus")
+               }
+)
+#' @rdname CompadreMatrixMethods
+#' @export
+setMethod("stageStatus", signature = "CompadreMorData", 
+          function(object){
+            if(class(object) %in% "CompadreM"){
+              return(object@matrixClass$matrixClassOrganized)
+            }
+            if(class(object) %in% "CompadreData"){
+              return( lapply(object@data$mat, function(M){ M@matrixClass$matrixClassOrganized }) )
+            }
+          }
+)
+setGeneric("MatrixClassOrganized", 
+               function(object){
+                   standardGeneric("MatrixClassOrganized")
+               }
+)
+#' @rdname CompadreMatrixMethods
+#' @export
+setMethod("MatrixClassOrganized", signature = "CompadreMorData", 
+          function(object){
+            if(class(object) %in% "CompadreM"){
+              return(object@matrixClass$matrixClassOrganized)
+            }
+            if(class(object) %in% "CompadreData"){
+              return( lapply(object@data$mat, function(M){ M@matrixClass$matrixClassOrganized }) )
+            }
+          }
+)

--- a/R/CompadreM.R
+++ b/R/CompadreM.R
@@ -16,6 +16,14 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+################################################################################
+#' Methods for working with matrices in com(p)adre
+#' 
+#' This page describes methods for accessing any matrix information from 
+#' CompadreM and CompadreData objects.
+#' 
+#' @name CompadreMatrixMethods
+
 setClass("CompadreM",
          slots = c(
            matA = "matrix",
@@ -26,9 +34,10 @@ setClass("CompadreM",
          )
 )
 
-## ---------------------------------------------------------------------
-## define a method for initialize
+################################################################################
+## Initialize & check
 
+## define a method for initialize (does not need to be documented)
 #' @importFrom methods callNextMethod validObject
 setMethod("initialize", "CompadreM",
           function(.Object, ...) {
@@ -44,7 +53,7 @@ setMethod("initialize", "CompadreM",
           })
 
 ## ---------------------------------------------------------------------
-## define validity check function
+## define validity check function (does not need to be documented)
 validCompadreM <- function(object) {
   errors <- character()
   ###matrices
@@ -102,6 +111,11 @@ validCompadreM <- function(object) {
   }
 }
 setValidity("CompadreM", validCompadreM)
+
+
+## -----------------------------------------------------------------------------
+## define a method for showing the object (does not need to be documented)
+# show
 
 setMethod("show", signature = (object ="CompadreM"),
           function (object){

--- a/R/DBToFlat.R
+++ b/R/DBToFlat.R
@@ -39,26 +39,20 @@ DBToFlat <- function(db, onlyMatA = FALSE){
     }
   }
   
-  db@metadata$Amatrix <- NULL
-  for (i in 1:nrow(db@metadata)){
-    db@metadata$classnames[i] <- paste(db@mat[[i]]@matrixClass$MatrixClassAuthor,
-                                       collapse = " | ")
-    db@metadata$matrixA[i] <- paste("[", paste(t(db@mat[[i]]@matA), collapse=" "), "]",
-                                    sep = "")
-  }
-  
+  newdata <- metadata(db)
+  newdata$MatrixClassAuthor <- sapply(MatrixClassAuthor(db), function(x) {
+                                      paste(x, collapse = " | ") })
+  newdata$matA <- sapply(matA(db), function(x){
+                         paste("[", paste(t(x), collapse=" "), "]", sep = "") })
   if(onlyMatA == FALSE) {
-    for (i in 1:nrow(db@metadata)){
-      db@metadata$matrixU[i] <- paste("[", paste(t(db@mat[[i]]@matU), collapse=" "),
-                                      "]", sep = "")
-      db@metadata$matrixF[i] <- paste("[", paste(t(db@mat[[i]]@matF), collapse=" "),
-                                      "]", sep = "")
-      db@metadata$matrixC[i] <- paste("[", paste(t(db@mat[[i]]@matC), collapse=" "),
-                                      "]", sep = "")
-    }
+    newdata$matU <- sapply(matU(db), function(x){
+                          paste("[", paste(t(x), collapse=" "), "]", sep = "") })
+    newdata$matF <- sapply(matF(db), function(x){
+                          paste("[", paste(t(x), collapse=" "), "]", sep = "") })
+    newdata$matC <- sapply(matC(db), function(x){
+                          paste("[", paste(t(x), collapse=" "), "]", sep = "") })
   }
-  
-  return(db@metadata)
+  return(newdata)
 }
 
 #' @rdname DBToFlat

--- a/R/checkspecies.R
+++ b/R/checkspecies.R
@@ -73,5 +73,5 @@ findSpecies <- function(species, db) {
       db <- methods::as(db, "CompadreData")
     }
   }
-  tolower(species) %in% tolower(gsub('_', ' ', db@metadata$SpeciesAccepted))
+  tolower(species) %in% tolower(gsub('_', ' ', SpeciesAccepted(db)))
 }

--- a/R/collapseMatrix.R
+++ b/R/collapseMatrix.R
@@ -10,6 +10,9 @@
 #' the stable distribution.\cr\cr
 #' Note: this function is only valid for models without clonality.
 #'
+#' @param CompadreM a CompadreM object. If this argument is not empty, then 
+#'   matU, matF and matC are extracted from the CompadreM object, and
+#'   any objects passed to matU, matF and matC are ignored.
 #' @param matU Survival matrix
 #' @param matF Fecundity matrix
 #' @param matC A clonality matrix
@@ -49,6 +52,15 @@
 #' @export collapseMatrix
 #' 
 collapseMatrix <- function(matU, matF, matC, collapse) {
+  if(!is.null(CompadreM)){
+    if(!class(CompadreM) %in% "CompadreM") stop("CompadreM must be a CompadreM object")
+    if(!is.null(matU)) warning("Extracting matU from CompadreM, ignored given matU")
+    if(!is.null(matF)) warning("Extracting matF from CompadreM, ignored given matF")
+    if(!is.null(matC)) warning("Extracting matC from CompadreM, ignored given matC")
+    matU <- matU(CompadreM)
+    matF <- matF(CompadreM)
+    matC <- matC(CompadreM)
+  }
   matA <- matU + matF + matC
   if (any(is.na(matA))) {
     stop("Cannot collapse projection matrix containing NAs", call. = FALSE)

--- a/R/compareDBs.R
+++ b/R/compareDBs.R
@@ -32,37 +32,40 @@ compareDBs <- function(db1, db2, verbose = FALSE){
   db1 <- convertLegacyDB(db1)
   db2 <- convertLegacyDB(db2)
   
+  newdata1 <- data(db1)
+  newdata1 <- data(db2)
+
   #Quick summary
   cat("Quick Summary\n")
   
   #File 1
-  uniqueSource1 <- unique(paste(db1@metadata$Authors, " (",
-                                db1@metadata$YearPublication, ") ",
-                                db1@metadata$Journal, sep = ""))                     
-  db1@metadata$binomial <- db1@metadata$SpeciesAccepted
+  uniqueSource1 <- unique(paste(Authors(db1), " (",
+                                YearPublication(db1), ") ",
+                                Journal(db1), sep = ""))                     
+  binomial1 <- SpeciesAccepted(db1)
   
   cat(paste("File-1 contains the demographic and associated data from ", 
             length(uniqueSource1), " source papers, corresponding to ",
-            length(unique(db1@metadata$binomial))," accepted species, and ",
-            nrow(db1@metadata), " matrices.\n\n",sep=""))
+            length(unique(binomial1))," accepted species, and ",
+            NumberMatrices(db1), " matrices.\n\n",sep=""))
   
   #File 2
-  uniqueSource2 <- unique(paste(db2@metadata$Authors, " (",
-                                db2@metadata$YearPublication, ") ",
-                                db2@metadata$Journal, sep = ""))                      
-  db2@metadata$binomial <- db2@metadata$SpeciesAccepted
+  uniqueSource2 <- unique(paste(Authors(db2), " (",
+                                YearPublication(db2), ") ",
+                                Journal(db2), sep = ""))                      
+  binomial2 <- SpeciesAccepted(db2)
   
   cat(paste("File-2 contains the demographic and associated data for ", 
             length(uniqueSource2), " source papers, corresponding to ",
-            length(unique(db2@metadata$binomial))," accepted species, and ",
-            nrow(db2@metadata), " matrices.\n\n",sep=""))
+            length(unique(binomial2))," accepted species, and ",
+            NumberMatrices(db2), " matrices.\n\n",sep=""))
   
   if(verbose == TRUE){
     cat("Detailed summary\n")
     
     #Accepted species in File 1 that are not in File 2
-    sp1 <- unique(db1@metadata$binomial)
-    sp2 <- unique(db2@metadata$binomial)
+    sp1 <- unique(binomial1)
+    sp2 <- unique(binomial2)
     
     cat("Number of accepted species in File 1, based on latin binomial\n")
     print(length(sp1))
@@ -77,8 +80,8 @@ compareDBs <- function(db1, db2, verbose = FALSE){
     print(sp2[which(!sp2%in%sp1)])
     
     #Get unique author species for both files
-    asp1 <- unique(db1@metadata$SpeciesAuthor)
-    asp2 <- unique(db2@metadata$SpeciesAuthor)
+    asp1 <- unique(SpeciesAuthor(db1))
+    asp2 <- unique(SpeciesAuthor(db2))
     
     cat("Number of unique study-species combinations in File 1\n")
     print(length(asp1))
@@ -99,7 +102,7 @@ compareDBs <- function(db1, db2, verbose = FALSE){
     print(sort(uniqueSource1[which(!uniqueSource1%in%uniqueSource2)]))
     
     
-    cat("See the User Guide for definitiions\n")
+    cat("See the User Guide for definitions\n")
   }
 }
 

--- a/R/convertDB.R
+++ b/R/convertDB.R
@@ -11,7 +11,7 @@
 
 convertLegacyDB <- function(db) { 
   if (!inherits(db, 'CompadreData')){
-    requiredFields <- c('metadata', 'mat', 'matrixClass')
+    requiredFields <- c('metdata', 'mat', 'matrixClass')
     
     if(all(requiredFields %in% names(db))){
       db <- methods::as(db, "CompadreData")
@@ -24,6 +24,5 @@ convertLegacyDB <- function(db) {
            "the database API directly from R.")
     }
   }  
-  
   return(db)
 } 

--- a/R/identifyReprodStages.R
+++ b/R/identifyReprodStages.R
@@ -6,6 +6,9 @@
 #' combined propagule, pre-reproductive, reproductive and post-reproductive
 #' stages.
 #'
+#' @param CompadreM a CompadreM object. If this argument is not empty, then 
+#'   matF is extracted from the CompadreM object, and
+#'   any object passed to matF is ignored.
 #' @param matF A fecundity matrix
 #' @param na.handling One of \code{"return.na"}, \code{"return.true"}, or
 #'   \code{"return.false"}. Determines how values of \code{NA} within
@@ -45,7 +48,13 @@
 #'
 #' @export identifyReproStages
 #' 
-identifyReproStages <- function(matF, na.handling = "return.true") {
+identifyReproStages <- function(CompadreM = NULL, matF = NULL, 
+                                na.handling = "return.true") {
+  if(!is.null(CompadreM)){
+    if(!class(CompadreM) %in% "CompadreM") stop("CompadreM must be a CompadreM object")
+    if(!is.null(matF)) warning("Extracting matF from CompadreM, ignored given matF")
+    matF <- matF(CompadreM)
+  }
   if (!na.handling %in% c("return.na", "return.true", "return.false")) {
     stop("Argument na.handling must be either 'return.na', 'return.true', or 'return.false'")
   } else if (all(is.na(matF))) {

--- a/R/mergeDBs.R
+++ b/R/mergeDBs.R
@@ -31,30 +31,30 @@
 mergeDBs <- function(db1, db2) {
   
   db1 <- convertLegacyDB(db1)
-
+  newdata1 <- data(db1)
   db2 <- convertLegacyDB(db2)
+  newdata2 - data(db2)
+
   # Probably don't want to combine databases without matching information
-  if(!identical(names(db1@metadata), names(db2@metadata))) {
+  if(!identical(names(metadata(db1)), names(metadata(db2)))) {
     stop("Metadata components do not have identical names. ",
          "Make sure the metadata \n",
          "in each is identical to other.", Call. = FALSE)
   }
   
   out <- methods::new('CompadreData',
-                      metadata = rbind(db1@metadata,
-                                       db2@metadata),
-                      mat = c(db1@mat,
-                              db2@mat),
-                      version = db1@version)
+                      data = rbind(data(db1),
+                                   data(db2)),
+                      version = VersionData(db1))
   
   # create indexes to check output
-  seq1 <- seq_len(dim(db1@metadata)[1])
-  seq2 <- seq(max(seq1) + 1, dim(out@metadata)[1], by = 1)
+  seq1 <- seq_len(dim(metadata(db1))[1])
+  seq2 <- seq(max(seq1) + 1, dim(metadata(out))[1], by = 1)
   
-  if(!identical(db1@mat, 
-                out@mat[seq1]) |
-     !identical(db2@mat, 
-                out@mat[seq2])) {
+  if(!identical(mat(db1), 
+                mat(out)[seq1]) |
+     !identical(mat(db2), 
+                mat(out)[seq2])) {
     
     # Not sure how to report this as an error other than it being my mistake
     stop("Something went wrong. Send a reproducible",
@@ -65,31 +65,25 @@ mergeDBs <- function(db1, db2) {
   # then add in that information. 
   # I will work on making these messages a bit prettier in the not
   # so distant future.
-  if(!grepl('subset created', out@version$Version)) {
-    out@version$Version <- paste(db1@version$Version,
-                                 " - merge made on ",
-                                 format(Sys.time(), 
-                                        "%b_%d_%Y"),
-                                 sep = "")
+  outVersion <- VersionData(out)
+  if(!grepl('subset created', Version(out))) {
+    outVersion$Version <- paste(Version(out),
+                                " - merge made on ",
+                                format(Sys.time(), 
+                                       "%b_%d_%Y"),
+                                sep = "")
     
-    out@version$DateCreated <- paste(db1@version$DateCreated,
+    outVersion$DateCreated <- paste(DateCreated(db1),
                                      " - merge made on ",
                                      format(Sys.time(), 
                                             "%b_%d_%Y"),
                                      sep = "") 
   }
 
-  out@version$NumberAcceptedSpecies <- length(
-    unique(out@metadata$SpeciesAccepted)
-  )
-  out@version$NumberStudies <- length(
-    unique(
-      paste0(out@metadata$Authors,
-             out@metadata$Journal,
-             out@metadata$YearPublication))
-  )
-
-  out@version$NumberMatrices <- length(out@mat)
+  outVersion$NumberAcceptedSpecies <- NumberAcceptedSpecies(out)
+  outVersion$NumberStudies <- NumberStudies(out)
+  outVersion$NumberMatrices <- NumberMatrices(out)
   
+  out@version <- outVersion
   return(out)
 }

--- a/R/rearrangeMatrix.R
+++ b/R/rearrangeMatrix.R
@@ -5,6 +5,9 @@
 #' the matrix model into a standardized set of stages (e.g. propagule,
 #' pre-reproductive, reproductive, and post-reproductive).
 #'
+#' @param CompadreM a CompadreM object. If this argument is not empty, then 
+#'   matU, matF and matrixStages are extracted from the CompadreM object, and
+#'   any objects passed to matU, matF and matrixStages are ignored.
 #' @param matU Survival matrix
 #' @param matF Fecundity matrix
 #' @param matrixStages A character vector identifying the matrix stages
@@ -32,7 +35,17 @@
 #' 
 #' @export rearrangeMatrix
 #' 
-rearrangeMatrix <- function(matU, matF, reproStages, matrixStages) {
+rearrangeMatrix <- function(CompadreM = NULL, matU = NULL, matF = NULL, 
+                            reproStages, matrixStages = NULL) {
+  if(!is.null(CompadreM)){
+    if(!class(CompadreM) %in% "CompadreM") stop("CompadreM must be a CompadreM object")
+    if(!is.null(matU)) warning("Extracting matU from CompadreM, ignored given matU")
+    if(!is.null(matF)) warning("Extracting matF from CompadreM, ignored given matF")
+    matU <- matU(CompadreM)
+    matF <- matF(CompadreM)
+    if(!is.null(stageNames)) warning("Extracting matrixStages from CompadreM, ignored given matrixStages")
+    matrixStages <- stageNames(CompadreM)
+  }
   if (!(identical(dim(matU), dim(matF)) && identical(ncol(matF),
                                                      length(reproStages)))) {
     stop("Expecting matrices with equal dimensions", call. = FALSE)

--- a/R/splitMatrix.R
+++ b/R/splitMatrix.R
@@ -3,6 +3,9 @@
 #' This function splits a matrix population model into three constituent matrices, U (growth and survival processes), F (sexual reproduction) and C (clonal reproduction).
 #' Warning! The functionality is very basic - it assumes that sexual reproduction is located in the top row of the matrix, and that everything else is growth or survival (the U matrix). Clonality is assumed to be non-existant.
 #'
+#' @param CompadreM a CompadreM object. If this argument is not empty, then 
+#'   matA is extracted from the CompadreM object, and
+#'   any object passed to matA is ignored.
 #' @param matA A matrix population model.
 #' 
 #' @return A list of three matrices: `matU`,`matF` and `matC`.
@@ -18,6 +21,11 @@
 #' @export splitMatrix
 #' 
 splitMatrix <- function(matA){
+  if(!is.null(CompadreM)){
+    if(!class(CompadreM) %in% "CompadreM") stop("CompadreM must be a CompadreM object")
+    if(!is.null(matA)) warning("Extracting matU from CompadreM, ignored given matU")
+    matA <- matA(CompadreM)
+  }
   matU <- matA
   matU[1,] <- rep(0,ncol(matA))
   matF <- matrix(c(matA[1,],rep(0,ncol(matA)*(nrow(matA)-1))),ncol=ncol(matA),byrow = TRUE)

--- a/R/subsetDB.R
+++ b/R/subsetDB.R
@@ -31,32 +31,33 @@ subsetDB <- function(db, sub){
   db <- convertLegacyDB(db)
   
   e <- substitute(sub)
-  r <- eval(e, db@metadata, parent.frame())
+  r <- eval(e, metadata(db), parent.frame())
   subsetID <- seq_len(length(r))[r & !is.na(r)]
   
   # First make a copy of the database
   ssdb <- db
 
   # Subset the sub-parts of the database
-  ssdb@metadata <- ssdb@metadata[subsetID,]
-  ssdb@mat <- ssdb@mat[subsetID]
+  data(ssdb) <- data(ssdb)[subsetID, ]
   
   # Version information is retained, but modified as follows.
   if("version" %in% methods::slotNames(ssdb)){
-    ssdb@version$Version <- paste0(ssdb@version$Version,
+    newversion <- version(ssdb)
+    newversion$Version <- paste0(Version(ssdb),
                                    " - subset created on ",
                                    format(Sys.time(), "%b_%d_%Y")
                                   )
-    ssdb@version$DateCreated <- paste0(ssdb@version$DateCreated,
+    newversion$DateCreated <- paste0(DateCreated(ssdb),
                                        " - subset created on ",
                                        format(Sys.time(), "%b_%d_%Y")
                                       )
-    ssdb@version$NumberAcceptedSpecies <- length(unique(ssdb@metadata$SpeciesAccepted))
-    ssdb@version$NumberStudies <- length(unique(paste0(ssdb@metadata$Authors,
-                                                       ssdb@metadata$Journal,
-                                                       ssdb@metadata$YearPublication
+    newversion$NumberAcceptedSpecies <- length(unique(SpeciesAccepted(ssdb)))
+    newversion$NumberStudies <- length(unique(paste0(Authors(ssdb),
+                                                       Journal(ssdb),
+                                                       YearPublication(ssdb)
                                                       )))
-    ssdb@version$NumberMatrices <- length(ssdb@mat)
+    newversion$NumberMatrices <- dim(data(ssdb)[1])
+    ssdb@version <- newversion
   }
   return(ssdb)
 }


### PR DESCRIPTION
Changes to class structure and associated changes in S4 addessing, accessor functions for data, small updates to functions. Closes 4 issues.

1. Changed the structure of CompadreData object, so that now there are two slots: 1. 'data', which contains a data.frame with the original 'metadata' plus a list column 'mat' containing the CompadreM objects, and 2. a 'version' slot which contains version information. This addresses issues #27 and #29 at github.com/jonesor/Rcompadre and ties the order metadata and matrices more closely together.
2. Accessor functions for almost anything contained in the databases have been added, which addresses issue #23. It is still possible to access matrices and metadata separately to one another, even though they are now contained in one data.frame.
3. All functions and methods have been updated to use these accessor functions rather than accessing information directly from the slots (completes issue #15). If we wish to change the structure of the classes in the future, this minimises the work needed to go into making sure the methods and functions work with the new structure, as we only have to change the accessor functions rather than everything. Accessor functions should be used in the future rather than accessing information directly from the slots.
4. Added a pseudo superclass CompadreMorData which allows methods to be utilised by both classes (these pertain to matrices and matrixClass information).
5. Changed collapseMatrix, getMeanMatF, IdentifyReprodStages, rearrangeMatrix, splitMatrix so that they work with CompadreM objects as well as specific matrices that have been passed to them.