### PR TITLE
Update actions/cache from v2 to v4 in all workflows

### DIFF
--- a/.github/workflows/devel_build_check.yaml
+++ b/.github/workflows/devel_build_check.yaml
@@ -63,7 +63,7 @@ jobs:
 #Windows
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/devel_pull_check.yaml
+++ b/.github/workflows/devel_pull_check.yaml
@@ -62,7 +62,7 @@ jobs:
 #Windows
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/main_check.yaml
+++ b/.github/workflows/main_check.yaml
@@ -66,7 +66,7 @@ jobs:
 #Windows
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/.github/workflows/weekly-build-check.yml
+++ b/.github/workflows/weekly-build-check.yml
@@ -66,7 +66,7 @@ jobs:
 #Windows
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}


### PR DESCRIPTION
actions/cache v1 and v2 are deprecated and now cause workflow failures.
Updated all four workflow files to use actions/cache@v4.

https://claude.ai/code/session_01Uhx9p13UsVXL31qMTAUj2n